### PR TITLE
Final FCrelax after XBraid is finished

### DIFF
--- a/braid/_braid.h
+++ b/braid/_braid.h
@@ -264,6 +264,7 @@ typedef struct _braid_Core_struct
    braid_Int              initiali;         /**< initial condition grid index (0: default; -1: periodic ) */
 
    braid_Int              access_level;     /**< determines how often to call the user's access routine */ 
+   braid_Int              finalFCrelax;     /**< determines if a final FCrelax is performed (default 0=false) */ 
    braid_Int              print_level;      /**< determines amount of output printed to screen (0,1,2,3) */
    braid_Int              io_level;         /**< determines amount of output printed to files (0,1) */
    braid_Int              seq_soln;         /**< boolean, controls if the initial guess is from sequential time stepping*/

--- a/braid/_braid.h
+++ b/braid/_braid.h
@@ -222,7 +222,7 @@ typedef struct
    braid_BaseVector  *va_alloc;      /**< original memory allocation for va */
    braid_BaseVector  *fa_alloc;      /**< original memory allocation for fa */
 
-   braid_BaseVector ulast;          /**< stores last time step */
+   braid_BaseVector   ulast;         /**< stores vector at last time step */
 
 } _braid_Grid;
 
@@ -943,6 +943,10 @@ braid_Int
 _braid_Drive(braid_Core core, 
              braid_Real localtime);
 
+
+/**
+ * Retrieve uvector at last time-step
+ */
 braid_Int
 _braid_UGetLast(braid_Core        core,
                 braid_BaseVector *u_ptr);

--- a/braid/braid.c
+++ b/braid/braid.c
@@ -204,6 +204,7 @@ braid_Init(MPI_Comm               comm_world,
    braid_Int              print_level     = 2;              /* Default print level */
    braid_Int              io_level        = 1;              /* Default output-to-file level */
    braid_Int              access_level    = 1;              /* Default access level */
+   braid_Int              finalFCrelax    = 0;              /* Default final FCrelax */
    braid_Int              tnorm           = 2;              /* Default temporal norm */
    braid_Real             tol             = 1.0e-09;        /* Default absolute tolerance */
    braid_Int              warm_restart    = 0;              /* Default is no warm restart */
@@ -253,6 +254,7 @@ braid_Init(MPI_Comm               comm_world,
    _braid_CoreElt(core, sync)            = NULL;
 
    _braid_CoreElt(core, access_level)    = access_level;
+   _braid_CoreElt(core, finalFCrelax)    = finalFCrelax;
    _braid_CoreElt(core, tnorm)           = tnorm;
    _braid_CoreElt(core, print_level)     = print_level;
    _braid_CoreElt(core, io_level)        = io_level;
@@ -778,6 +780,16 @@ braid_SetAccessLevel(braid_Core  core,
 {
    _braid_CoreElt(core, access_level) = access_level;
 
+   return _braid_error_flag;
+}
+
+/*--------------------------------------------------------------------------
+ *--------------------------------------------------------------------------*/
+
+braid_Int
+braid_SetFinalFCRelax(braid_Core core)
+{
+   _braid_CoreElt(core, finalFCrelax) = 1;
    return _braid_error_flag;
 }
 

--- a/braid/braid.h
+++ b/braid/braid.h
@@ -843,6 +843,16 @@ braid_SetAccessLevel(braid_Core  core,          /**< braid_Core (_braid_Core) st
                      braid_Int   access_level   /**< desired access_level */
                      );
 
+
+/** 
+ * Perform a final FCRelax after XBraid finishes. 
+ * This can be useful in order to 
+ * - store the last time-point vector in grid's 'ulast'. It can be retrieve afterwards by calling _braid_UGetLast()
+ * - gather gradient information when solving the adjoint equation with XBraid. The users 'my_step' function for the adjoint time-stepper should compute gradients only if braid's 'done' flag is true
+ */
+braid_Int
+braid_SetFinalFCRelax(braid_Core core);
+
 /**
  * Split MPI commworld into *comm_x* and *comm_t*, the 
  * spatial and temporal communicators.  The total number of processors

--- a/braid/braid.hpp
+++ b/braid/braid.hpp
@@ -547,6 +547,8 @@ public:
 
    void SetAccessLevel(braid_Int access_level) { braid_SetAccessLevel(core, access_level); }
 
+   void SetFinalFCRelax() {braid_SetFinalFCRelax(core); }
+
    void SetFMG() { braid_SetFMG(core); }
 
    void SetNFMG(braid_Int k) { braid_SetNFMG(core, k); }

--- a/braid/braid_status.c
+++ b/braid/braid_status.c
@@ -597,6 +597,7 @@ ACCESSOR_FUNCTION_SET1(Step, OldFineTolx,   Real)
 ACCESSOR_FUNCTION_SET1(Step, TightFineTolx, Real)
 ACCESSOR_FUNCTION_SET1(Step, RFactor,       Real)
 ACCESSOR_FUNCTION_SET1(Step, RSpace,        Real)
+ACCESSOR_FUNCTION_GET1(Step, Done,          Int)
 
 /*--------------------------------------------------------------------------
  * BufferStatus Routines

--- a/braid/braid_status.h
+++ b/braid/braid_status.h
@@ -549,6 +549,7 @@ ACCESSOR_HEADER_SET1(Step, OldFineTolx,   Real)
 ACCESSOR_HEADER_SET1(Step, TightFineTolx, Real)
 ACCESSOR_HEADER_SET1(Step, RFactor,       Real)
 ACCESSOR_HEADER_SET1(Step, RSpace,        Real)
+ACCESSOR_HEADER_GET1(Step, Done,          Int)
 
 /*--------------------------------------------------------------------------
  * BufferStatus Prototypes: They just wrap the corresponding Status accessors

--- a/braid/drive.c
+++ b/braid/drive.c
@@ -664,15 +664,18 @@ _braid_Drive(braid_Core  core,
     * -> do a sequential time-stepping, if max_levels==1
     * -> gather gradient information when solving adjoint equation with XBraid. The users 'my_step' function should compute gradients only if braid's 'done' flag is true
    */
-   braid_Int nrelax_orig = _braid_CoreElt(core, nrels)[0];
-   braid_Int done_orig = done;
-   _braid_CoreElt(core, nrels)[0] = 1;
-   _braid_CoreElt(core, done) = 1;
+   if (_braid_CoreElt(core, finalFCrelax))
+   {
+      braid_Int nrelax_orig = _braid_CoreElt(core, nrels)[0];
+      braid_Int done_orig = done;
+      _braid_CoreElt(core, nrels)[0] = 1;
+      _braid_CoreElt(core, done) = 1;
 
-   _braid_FCRelax(core, 0);
+      _braid_FCRelax(core, 0);
 
-   _braid_CoreElt(core, nrels)[0] = nrelax_orig;
-   _braid_CoreElt(core, done) = done_orig;
+      _braid_CoreElt(core, nrels)[0] = nrelax_orig;
+      _braid_CoreElt(core, done) = done_orig;
+   }
 
    /* If sequential time-marching, evaluate the tape */
    if ( adjoint && max_levels <= 1 )

--- a/braid/drive.c
+++ b/braid/drive.c
@@ -648,6 +648,17 @@ _braid_Drive(braid_Core  core,
       _braid_FRestrict(core, level);
    }
 
+   /* Allow final access to Braid by carrying out an F-relax to generate points */
+   /* Record it only if sequential time stepping */
+   if (max_levels == 1 || access_level >= 1) 
+   {
+      if (max_levels > 1)
+      {
+         _braid_CoreElt(core, record) = 0;
+      }
+      _braid_FAccess(core, 0, 1);
+   }
+
    /* Do one final F-C-Relaxation sweep in order to:
     * -> store the last time-point vector in grid's 'ulast'. Retrieve it by calling _braid_UGetLast()
     * -> do a sequential time-stepping, if max_levels==1

--- a/braid/drive.c
+++ b/braid/drive.c
@@ -650,7 +650,7 @@ _braid_Drive(braid_Core  core,
 
    /* Do one final F-C-Relaxation sweep in order to:
     * -> store the last time-point vector in grid's 'ulast'. Retrieve it by calling _braid_UGetLast()
-    * -> do a sequential time-stepping, if max_levels==1 (TODO: DOES THIS WORK IF nprocs>1??)
+    * -> do a sequential time-stepping, if max_levels==1
     * -> gather gradient information when solving adjoint equation with XBraid. The users 'my_step' function should compute gradients only if braid's 'done' flag is true
    */
    braid_Int nrelax_orig = _braid_CoreElt(core, nrels)[0];

--- a/braid/grid.c
+++ b/braid/grid.c
@@ -49,7 +49,10 @@ _braid_GridInit(braid_Core     core,
    ta = _braid_CTAlloc(braid_Real, iupper-ilower+3);
    _braid_GridElt(grid, ta_alloc) = ta;
    _braid_GridElt(grid, ta)       = ta+1;  /* shift */
-   
+
+   /* Initialize last time step storage with NULL */
+   _braid_GridElt(grid, ulast) = NULL;
+
    *grid_ptr = grid;
 
    return _braid_error_flag;

--- a/braid/relax.c
+++ b/braid/relax.c
@@ -34,6 +34,9 @@ _braid_FCRelax(braid_Core  core,
    braid_Int      *nrels    = _braid_CoreElt(core, nrels);
    _braid_Grid   **grids    = _braid_CoreElt(core, grids);
    braid_Int       ncpoints = _braid_GridElt(grids[level], ncpoints);
+   braid_Int       done     = _braid_CoreElt(core, done);
+   braid_Int       ntime    = _braid_CoreElt(core, ntime);
+   braid_Int       storage  = _braid_CoreElt(core, storage);
 
    braid_BaseVector  u;
    braid_Int         flo, fhi, fi, ci;
@@ -64,6 +67,17 @@ _braid_FCRelax(braid_Core  core,
          {
             _braid_Step(core, level, fi, NULL, u);
             _braid_USetVector(core, level, fi, u, 0);
+
+            /* If braid is finished, store last time step */
+            if (done && fi == ntime && level == 0 && storage < 0)
+            {
+               if (_braid_GridElt(grids[level], ulast) != NULL)
+               {
+                  _braid_BaseFree(core, app, _braid_GridElt(grids[level], ulast));
+                  _braid_GridElt(grids[level], ulast) = NULL;
+               }
+               _braid_BaseClone(core, app,  u, &(_braid_GridElt(grids[level], ulast)));
+            }
          }
 
          /* C-relaxation */
@@ -71,6 +85,16 @@ _braid_FCRelax(braid_Core  core,
          {
             _braid_Step(core, level, ci, NULL, u);
             _braid_USetVector(core, level, ci, u, 1);
+            /* If braid is finished, store last time step */
+            if (done && ci == ntime && level == 0 && storage < 0)
+            {
+               if (_braid_GridElt(grids[level], ulast) != NULL)
+               {
+                  _braid_BaseFree(core, app, _braid_GridElt(grids[level], ulast));
+                  _braid_GridElt(grids[level], ulast) = NULL;
+               }
+               _braid_BaseClone(core, app,  u, &(_braid_GridElt(grids[level], ulast)));
+            }
          }
 
          /* if ((flo <= fhi) && (interval == ncpoints)) */

--- a/braid/uvector.c
+++ b/braid/uvector.c
@@ -201,6 +201,32 @@ _braid_UGetVector(braid_Core         core,
    return _braid_error_flag;
 }
 
+/* Retrieve the last time-step vector */
+braid_Int
+_braid_UGetLast(braid_Core        core,
+                braid_BaseVector *u_ptr)
+{
+   _braid_Grid       **grids = _braid_CoreElt(core, grids);
+   int                 ntime = _braid_CoreElt(core, ntime);
+   braid_BaseVector    ulast;
+
+   /* Get vector at last time step*/
+   if (_braid_CoreElt(core, storage) < 0 )
+   {
+      ulast  = _braid_GridElt(grids[0], ulast);
+   }
+   else
+   {
+     _braid_UGetVectorRef(core, 0, ntime, &ulast);
+   }
+
+  *u_ptr = ulast;
+
+   return _braid_error_flag;
+
+}
+
+
 /*----------------------------------------------------------------------------
  * Stores the u-vector on grid 'level' at point 'index'.  If 'index' is my "send
  * index", a send is initiated to a neighbor processor.  If 'move' is true, the


### PR DESCRIPTION
Perform an optional final FCrelax after XBraid has finished. Turn on by calling braid_SetFinalFCRelax(core). 

This feature is useful to 
* store the last time-point vector in grid's 'ulast'. FCrelax has been modified to copy the state at the last time-point into 'ulast'. This state vector can be accessed by the user by calling _braid_UGetLast(...)
 * gather gradient information when solving the adjoint equation with XBraid. The users 'my_step' function for the adjoint time-stepper should compute gradients only if braid's 'done' flag is true

Note the interplay with the final call to FAccess: in the case of max_levels==1 and finalFCrelax==true, a sequential time-stepping will be done twice, once from the final call to FAccess and once from the final call to FCrelax. 
